### PR TITLE
Enable threshold.config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@ NFQUEUE is an iptables and ip6tables target which delegate the decision on packe
 All traffic will be analyzed by Suricata itself.
 
 Suricata rules are managed by Pulledpork.
-Alert logs are parsed by SnortALog and are available inside the Dashboard. 
 
 Manually enable/disable Suricata
 ================================

--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -64,7 +64,7 @@ rule-files:
 
 classification-file: /etc/suricata/classification.config
 reference-config-file: /etc/suricata/reference.config
-# threshold-file: /etc/suricata/threshold.config
+threshold-file: /etc/suricata/threshold.config
 
 
 ##


### PR DESCRIPTION
I'd like to enable threshold.config in suricata.yaml configuration.
The referenced file (/etc/suricata/threshold.config) is empty, nothing should change.

NethServer/dev#5104 
