### PR TITLE
api: fix IPS enable/disable action

### DIFF
--- a/api/configuration/update
+++ b/api/configuration/update
@@ -39,6 +39,7 @@ case $action in
         alert=$(echo $data | jq -rc '[.categories[] | select(.status == "alert") | .name] | map(tostring) | join(",")')
 
         /sbin/e-smith/config setprop suricata BlockCategories "$block" AlertCategories "$alert" status "$(_get status)"
+        /sbin/e-smith/config setprop firewall nfqueue "$(_get status)"
         /sbin/e-smith/signal-event -j nethserver-suricata-save
         ;;
 


### PR DESCRIPTION
The firewall `nfqueue` property must be synchronized with suricata
`status` property otherwise no traffic will be sent to the IPS.