### PR TITLE
Switch suricata to repeat mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,19 +13,14 @@ Suricata rules are managed by Pulledpork.
 Manually enable/disable Suricata
 ================================
 
-Suricata will analyze network traffic only if ``nfqueue`` property inside the ``firewall`` key is set to enabled.
-The web interface will take care of this by assuring both ``firewall{nfqueue}`` and ``suricata{status}`` are set to ``enabled`` (or ``disabled``).
-
 Enabling: ::
 
-  config setprop firewall nfqueue enabled
   config setprop suricata status enabled
   signal-event firewall-adjust
   signal-event nethserver-suricata-save
 
 Disabling: ::
 
-  config setprop firewall nfqueue disabled
   config setprop suricata status disabled
   signal-event firewall-adjust
   signal-event nethserver-suricata-save
@@ -35,13 +30,3 @@ Troubleshooting
 ===============
 
 When troubleshooting network traffic, just remember that Suricata will intercept all the traffic.
-
-To temporary disable Suricata use: ::
-
-  config setprop firewall nfqueue disabled
-  signal-event firewall-adjust
-
-To re-enable Suricata: ::
-  
-  config setprop firewall nfqueue enabled
-  signal-event firewall-adjust

--- a/api/configuration/update
+++ b/api/configuration/update
@@ -39,7 +39,6 @@ case $action in
         alert=$(echo $data | jq -rc '[.categories[] | select(.status == "alert") | .name] | map(tostring) | join(",")')
 
         /sbin/e-smith/config setprop suricata BlockCategories "$block" AlertCategories "$alert" status "$(_get status)"
-        /sbin/e-smith/config setprop firewall nfqueue "$(_get status)"
         /sbin/e-smith/signal-event -j nethserver-suricata-save
         ;;
 

--- a/nethserver-suricata.spec
+++ b/nethserver-suricata.spec
@@ -10,7 +10,8 @@ Source1: %{name}-ui.tar.gz
 BuildArch: noarch
 
 Requires: suricata
-Requires: nethserver-firewall-base, nethserver-pulledpork
+Requires: nethserver-firewall-base > 3.9.2
+Requires: nethserver-pulledpork
 
 Conflicts: nethserver-snort
 

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -1,6 +1,7 @@
 {
     my $status = $suricata{'status'} || 'enabled';
     if ($status eq 'enabled') {
-        $OUT.="NFQUEUE(bypass) all+ all+:!127.0.0.1/32 - - - - - - !0x10/0x10\n";
+        $OUT.="ACCEPT $FW $FW\n";
+        $OUT.="NFQUEUE(bypass) all+ all+ - - - - - - !0x10/0x10\n";
     }
 }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -1,0 +1,6 @@
+{
+    my $status = $suricata{'status'} || 'enabled';
+    if ($status eq 'enabled') {
+        $OUT.="NFQUEUE(bypass) all+ all+:!127.0.0.1/32 - - - - - - !0x10/0x10\n";
+    }
+}

--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -1378,12 +1378,12 @@ profiling:
 # On linux >= 3.6, you can set the fail-open option to yes to have the kernel
 # accept the packet if suricata is not able to keep pace.
 nfq:
-#  mode: accept
-#  repeat-mark: 1
-#  repeat-mask: 1
+  mode: repeat
+  repeat-mark: 16
+  repeat-mask: 16
 #  route-queue: 2
 #  batchcount: 20
-#  fail-open: yes
+  fail-open: yes
 
 #nflog support
 nflog:

--- a/root/etc/e-smith/templates/etc/suricata/threshold.config/40suppress
+++ b/root/etc/e-smith/templates/etc/suricata/threshold.config/40suppress
@@ -8,7 +8,5 @@
         next if ($bootproto ne 'none');
         $OUT .= "# disable FP for wpad.dat\n";
         $OUT .= "suppress gen_id 1, sig_id 2022913, track by_dst, ip $ipaddr\n";
-        $OUT .= "# disable FP for hylafax\n";
-        $OUT .= "suppress gen_id 1, sig_id 2011124, track by_src, ip $ipaddr\n";
     }
 }

--- a/root/usr/share/nethesis/NethServer/Module/IPS.php
+++ b/root/usr/share/nethesis/NethServer/Module/IPS.php
@@ -113,7 +113,7 @@ class IPS extends \Nethgui\Controller\AbstractController
     public function initialize()
     {
         $this->readCategories();
-        $this->declareParameter('status', Validate::SERVICESTATUS, array(array('configuration', 'suricata', 'status'), array('configuration', 'firewall', 'nfqueue')));
+        $this->declareParameter('status', Validate::SERVICESTATUS, array('configuration', 'suricata', 'status'));
         $this->declareParameter('Categories', Validate::ANYTHING);
         parent::initialize();
     }


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6205

The exclusion for 127.0.0.1/32 in shorewall/rules may be required only on non-gateways (i.e. systems having only green zones), more tests needed.

See also NethServer/nethserver-firewall-base#143
