### PR TITLE
Clean IPS mark (0x10) before saving to CONNMARK

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/70clean_ips_mark
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/70clean_ips_mark
@@ -1,0 +1,3 @@
+# 70clean_ips_mark
+# clean ips marker before saving to connmark
+MARK(&0xffef):T - - - - - - 0x10/0x10


### PR DESCRIPTION
We have to send all packets to the IPS, so we clean the IPS-seen mark
in the packet before saving it in the CONNMARK. When a reply packet
comes in, having the bit unset, it goes to the IPS as expected.

NethServer/dev#6205