### PR TITLE
Clean IPS mark (0x10) immediately after NFQUEUE

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/mangle/70clean_ips_mark
+++ b/root/etc/e-smith/templates/etc/shorewall/mangle/70clean_ips_mark
@@ -1,3 +1,0 @@
-# 70clean_ips_mark
-# clean ips marker before saving to connmark
-MARK(&0xffef):T - - - - - - 0x10/0x10

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -3,5 +3,6 @@
     if ($status eq 'enabled') {
         $OUT.="ACCEPT \$FW \$FW\n";
         $OUT.="NFQUEUE(bypass) all+ all+ - - - - - - !0x10/0x10\n";
+        $OUT.="MARK(&0xffef) all+ all+\n";
     }
 }


### PR DESCRIPTION
We need to clear the mark as soon as suricata has seen the packet
to avoid problems with IPsec.

https://github.com/NethServer/dev/issues/6236