### PR TITLE
Improve perfomances

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -4,8 +4,13 @@
 {
     my $status = $suricata{'status'} || 'enabled';
     if ($status eq 'enabled') {
+        chomp(my $cpu_count = `nproc --all`);
+        my $nfq = '';
+        if ($cpu_count > 1) {
+            $nfq = "--queue-balance 0:" . ($cpu_count - 1) . " --queue-cpu-fanout";
+        }
         $OUT.="ACCEPT \$FW \$FW\n";
-        $OUT.="NFQUEUE(bypass) all+ all+ - - - - - - !0x10/0x10\n";
+        $OUT.="INLINE all+ all+ - - - - - - !0x10/0x10; -j NFQUEUE --queue-bypass $nfq\n";
         $OUT.="MARK(&0xffef) all+ all+\n";
     }
 }

--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -1448,7 +1448,7 @@ decoder:
 # If the argument specified is 0, the engine uses an internally defined
 # default limit.  On not specifying a value, we use no limits on the recursion.
 detect:
-  profile: medium
+  profile: high
   custom-values:
     toclient-groups: 3
     toserver-groups: 25

--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -1111,7 +1111,7 @@ host-mode: auto
 # Runmode the engine should use. Please check --list-runmodes to get the available
 # runmodes for each packet acquisition method. Defaults to "autofp" (auto flow pinned
 # load balancing).
-#runmode: autofp
+runmode: workers
 
 # Specifies the kind of flow load balancer used by the flow pinned autofp mode.
 #

--- a/root/etc/e-smith/templates/etc/sysconfig/suricata/10base
+++ b/root/etc/e-smith/templates/etc/sysconfig/suricata/10base
@@ -5,4 +5,12 @@
 # --group <group name>
 
 # Add options to be passed to the daemon
-OPTIONS="-q 0 --user suricata "
+{
+  chomp(my $cpu_count = `nproc --all`);
+  my $nfq = '';
+  for (my $q = 0; $q < $cpu_count; $q++) {
+    $nfq .= "-q $q ";
+  }
+
+  $OUT .= "OPTIONS=\"$nfq --user suricata \"";
+}


### PR DESCRIPTION
Notes:
* Due to [this iptables bug](https://git.netfilter.org/iptables/commit/?id=d1555a0906e35ba8d170613d5a43da64e527dbe1), we need to use an INLINE shorewall rule to enable nfqueue cpu fanout
* See this [LWN article](https://lwn.net/Articles/544379/) for details on cpu fanout

NethServer/dev#6283