### PR TITLE
config: set queue count limit to 16

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -5,6 +5,10 @@
     my $status = $suricata{'status'} || 'enabled';
     if ($status eq 'enabled') {
         chomp(my $cpu_count = `nproc --all`);
+        # max number of queues is 16
+        if ($cpu_count > 16) {
+            $cpu_count = 16;
+        }
         my $nfq = '';
         if ($cpu_count > 1) {
             $nfq = "--queue-balance 0:" . ($cpu_count - 1) . " --queue-cpu-fanout";

--- a/root/etc/e-smith/templates/etc/sysconfig/suricata/10base
+++ b/root/etc/e-smith/templates/etc/sysconfig/suricata/10base
@@ -7,6 +7,10 @@
 # Add options to be passed to the daemon
 {
   chomp(my $cpu_count = `nproc --all`);
+  # max number of queues is 16
+  if ($cpu_count > 16) {
+      $cpu_count = 16;
+  }
   my $nfq = '';
   for (my $q = 0; $q < $cpu_count; $q++) {
     $nfq .= "-q $q ";


### PR DESCRIPTION
Avoid error on startup:
```
  [ERRCODE: SC_ERR_INVALID_ARGUMENT(13)] - too much Netfilter queue registered (16)
```

NethServer/dev#6297