### PR TITLE
Query the statistic of last 4 hours

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -64,7 +64,7 @@ sub sorted_array
 my $db = esmith::ConfigDB->open_ro();
 if ($cmd eq 'statistics') {
     $ret = { alerts => undef, counters => { 'uptime' => 0, rules_loaded => 0, rules_failed => 0 }};
-    my $out = `curl --connect-timeout 2  -G http://localhost:5636/api/1/alerts -d time_range=864000s -s`;
+    my $out = `curl --connect-timeout 2  -G http://localhost:5636/api/1/alerts -d time_range=14400s -s`;
     my $eve = safe_decode_json($out);
     my $total = 0;
     my (%categories, %src, %dst);

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -27,7 +27,7 @@
     "sources": "Top 10 alerts by source IP",
     "destinations": "Top 10 alerts by destination IP",
     "hits": "Hits",
-    "last_updated_24h": "Last 24 hours",
+    "last_updated_4h": "Last 4 hours",
     "last_updated": "Since {time} ago",
     "no_data_found": "No data found",
     "counters": "Counters",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -30,7 +30,7 @@
         {{$t('dashboard.evebox')}}
         <span
           class="gray min-size right"
-        >{{$t('dashboard.last_updated_24h')}}</span>
+        >{{$t('dashboard.last_updated_4h')}}</span>
       </h2>
       <div class="row">
         <div class="col-sm-6">


### PR DESCRIPTION
When you trigger the dashboard API of suricata you query the last 10 days of statistic, on a real server this might let you wait about ten seconds to open the dashboard

We have reduced to the last 4 hours the query of statistic

https://github.com/NethServer/dev/issues/6357