### PR TITLE
Save the bypass bit (0x20) to the connection mark

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -16,6 +16,8 @@
         $OUT.="ACCEPT \$FW \$FW\n";
         $OUT.="INLINE all+ all+ - - - - - - 0x20/0x20; -j MARK --set-mark 0x10/0x10\n";
         $OUT.="INLINE all+ all+ - - - - - - !0x10/0x10; -j NFQUEUE --queue-bypass $nfq\n";
+        $OUT.="# Save the bypass mark immediately in the connection\n";
+        $OUT.="CONNMARK(|0x20) all+ all+ - - - - - - 0x20/0x20\n";
         $OUT.="MARK(&0xffef) all+ all+\n";
     }
 }


### PR DESCRIPTION
Due to how packets are processed, the bypass marker could be "lost".
This patch save the bypass bit in the connection as soon as suricata
sets it.

NethServer/dev#6661