### PR TITLE
Set stream depth to 1mb also for smb

### DIFF
--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -857,7 +857,7 @@ app-layer:
         dp: 139, 445
 
       # Stream reassembly size for SMB streams. By default track it completely.
-      #stream-depth: 0
+      stream-depth: 1mb
 
     # Note: NFS parser depends on Rust support: pass --enable-rust
     # to configure.


### PR DESCRIPTION
SMB doesn't use the default stream depth, we need to explicitly set it.

NethServer/dev#6677