### PR TITLE
Move Suricata bypass mark outside QoS mask

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -14,10 +14,10 @@
             $nfq = "--queue-balance 0:" . ($cpu_count - 1) . " --queue-cpu-fanout";
         }
         $OUT.="ACCEPT \$FW \$FW\n";
-        $OUT.="INLINE all+ all+ - - - - - - 0x20/0x20; -j MARK --set-mark 0x10/0x10\n";
+        $OUT.="INLINE all+ all+ - - - - - - 0x80/0x80; -j MARK --set-mark 0x10/0x10\n";
         $OUT.="INLINE all+ all+ - - - - - - !0x10/0x10; -j NFQUEUE --queue-bypass $nfq\n";
         $OUT.="# Save the bypass mark immediately in the connection\n";
-        $OUT.="CONNMARK(|0x20) all+ all+ - - - - - - 0x20/0x20\n";
+        $OUT.="CONNMARK(|0x80) all+ all+ - - - - - - 0x20/0x20\n";
         $OUT.="MARK(&0xffef) all+ all+\n";
     }
 }


### PR DESCRIPTION
Use 0x80 to mark connections to bypass

NethServer/dev#6681