### PR TITLE
Move suricata marks outside of QoS range

### DIFF
--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base10all20ipsnfq
@@ -14,10 +14,10 @@
             $nfq = "--queue-balance 0:" . ($cpu_count - 1) . " --queue-cpu-fanout";
         }
         $OUT.="ACCEPT \$FW \$FW\n";
-        $OUT.="INLINE all+ all+ - - - - - - 0x80/0x80; -j MARK --set-mark 0x10/0x10\n";
-        $OUT.="INLINE all+ all+ - - - - - - !0x10/0x10; -j NFQUEUE --queue-bypass $nfq\n";
-        $OUT.="# Save the bypass mark immediately in the connection\n";
-        $OUT.="CONNMARK(|0x80) all+ all+ - - - - - - 0x20/0x20\n";
-        $OUT.="MARK(&0xffef) all+ all+\n";
+        $OUT.="INLINE all+ all+ - - - - - - 0x80/0x80; -j MARK --set-mark 0x40/0x40\n";
+        $OUT.="INLINE all+ all+ - - - - - - !0x40/0x40; -j NFQUEUE --queue-bypass $nfq\n";
+        $OUT.="# Save the bypass mark immediately in the connection for traffic to $FW\n";
+        $OUT.="CONNMARK(|0x80) all+ all+ - - - - - - 0x80/0x80\n";
+        $OUT.="MARK(&0xffbf) all+ all+\n";
     }
 }

--- a/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
+++ b/root/etc/e-smith/templates/etc/suricata/suricata.yaml/10base
@@ -1665,10 +1665,10 @@ profiling:
 # directly accept all packets of a flow once a packet has been marked.
 nfq:
   mode: repeat
-  repeat-mark: 16
-  repeat-mask: 16
-  bypass-mark: 32
-  bypass-mask: 32
+  repeat-mark: 64
+  repeat-mask: 64
+  bypass-mark: 128
+  bypass-mask: 128
 #  route-queue: 2
 #  batchcount: 20
   fail-open: yes


### PR DESCRIPTION
As QoS supports a maximum of 63 marks, to avoid clashes with suricata,
move marks to the two highest bits (bit 6 is 64/0x40 and bit 7 is
128/0x80).

NethServer/dev#6690